### PR TITLE
feat: Add `KspLifecycleParticipant` to dynamically configure plugin executions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,8 @@
 # Info for AI Coding Agents
 
+skill: Kotlin architect
+skill: Java + Maven architect
+
 ## Development Guidelines
 
 - Use `git mv` command when renaming files to preserve git history, if possible
@@ -33,8 +36,8 @@
 - Avoid creating too many test methods. If multiple parameters can be tested in one scenario, go for it. Consider using parametrized tests.
 - Use function `Names with backticks` for test methods in Kotlin, e.g. "fun `should return 200 OK`()"
 - Avoid writing KDocs for tests, keep code self-documenting
-- Write Kotlin tests with [kotlin-test](https://github.com/JetBrains/kotlin/tree/master/libraries/kotlin.test),
-  [mockk](https://mockk.io/) and [Kotest-assertions](https://kotest.io/docs/assertions/assertions.html)
+- Write Kotlin tests with [Kotest-assertions](https://kotest.io/docs/assertions/assertions.html)
+  and [mockk](https://mockk.io/)
   with infix form assertions `shouldBe` instead of `assertEquals`.
 - Use Kotest's `withClue("<failure reason>")` to describe failure reasons, but only when the assertion is NOT obvious.
   Remove obvious cases for simplicity.

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>me.kpavlov.ksp.maven</groupId>
@@ -102,6 +103,12 @@
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
             <version>3.15.2</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <version>1</version>
             <scope>provided</scope>
         </dependency>
 
@@ -274,17 +281,17 @@
                         <!-- optional: limit format enforcement to just the files changed by this feature branch -->
                         <ratchetFrom>origin/main</ratchetFrom>
                         <java>
-                            <palantirJavaFormat />
+                            <palantirJavaFormat/>
                         </java>
                         <kotlin>
-                            <ktlint />
+                            <ktlint/>
                         </kotlin>
                         <markdown>
                             <includes>
                                 <!-- You have to set the target manually -->
                                 <include>**/*.md</include>
                             </includes>
-                            <flexmark />
+                            <flexmark/>
                         </markdown>
                         <pom>
                             <includes>

--- a/sample-project/pom.xml
+++ b/sample-project/pom.xml
@@ -41,6 +41,7 @@
                 <groupId>me.kpavlov.ksp.maven</groupId>
                 <artifactId>ksp-maven-plugin</artifactId>
                 <version>${ksp.plugin.version}</version>
+                <extensions>true</extensions>
                 <dependencies>
                     <dependency>
                         <groupId>me.kpavlov.ksp.maven</groupId>
@@ -49,22 +50,6 @@
                         <classifier>tests</classifier>
                     </dependency>
                 </dependencies>
-                <executions>
-                    <execution>
-                        <id>process-main-sources</id>
-                        <goals>
-                            <goal>process</goal>
-                        </goals>
-                        <phase>generate-sources</phase>
-                    </execution>
-                    <execution>
-                        <id>process-test-sources</id>
-                        <goals>
-                            <goal>process-test</goal>
-                        </goals>
-                        <phase>generate-test-sources</phase>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>

--- a/src/main/kotlin/me/kpavlov/ksp/maven/KspLifecycleParticipant.kt
+++ b/src/main/kotlin/me/kpavlov/ksp/maven/KspLifecycleParticipant.kt
@@ -1,0 +1,41 @@
+package me.kpavlov.ksp.maven
+
+import org.apache.maven.AbstractMavenLifecycleParticipant
+import org.apache.maven.execution.MavenSession
+import org.apache.maven.model.Plugin
+import org.apache.maven.model.PluginExecution
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Named
+@Singleton
+class KspLifecycleParticipant : AbstractMavenLifecycleParticipant() {
+
+    override fun afterProjectsRead(session: MavenSession) {
+        session.projects.forEach { project ->
+            val plugin = project.build.pluginsAsMap["me.kpavlov.ksp.maven:ksp-maven-plugin"]
+            if (plugin != null && plugin.isExtensions) {
+                addExecution(plugin, "process-main-sources", "process", "generate-sources")
+                addExecution(plugin, "process-test-sources", "process-test", "generate-test-sources")
+            }
+        }
+    }
+
+    private fun addExecution(
+        plugin: Plugin,
+        id: String,
+        goal: String,
+        phase: String,
+    ) {
+        if (plugin.executionsAsMap.containsKey(id)) {
+            return
+        }
+
+        val execution = PluginExecution().apply {
+            this.id = id
+            this.phase = phase
+            this.goals = listOf(goal)
+        }
+        plugin.addExecution(execution)
+    }
+}

--- a/src/main/resources/META-INF/sisu/javax.inject.Named
+++ b/src/main/resources/META-INF/sisu/javax.inject.Named
@@ -1,0 +1,1 @@
+me.kpavlov.ksp.maven.KspLifecycleParticipant

--- a/src/test/kotlin/me/kpavlov/ksp/maven/KspLifecycleParticipantTest.kt
+++ b/src/test/kotlin/me/kpavlov/ksp/maven/KspLifecycleParticipantTest.kt
@@ -1,0 +1,90 @@
+package me.kpavlov.ksp.maven
+
+import io.kotest.assertions.assertSoftly
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.apache.maven.execution.MavenSession
+import org.apache.maven.model.Build
+import org.apache.maven.model.Plugin
+import org.apache.maven.model.PluginExecution
+import org.apache.maven.project.MavenProject
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+
+class KspLifecycleParticipantTest {
+
+    private lateinit var participant: KspLifecycleParticipant
+    private lateinit var session: MavenSession
+    private lateinit var project: MavenProject
+    private lateinit var plugin: Plugin
+
+    @BeforeEach
+    fun setUp() {
+        participant = KspLifecycleParticipant()
+        session = mock(MavenSession::class.java)
+        project = mock(MavenProject::class.java)
+        val build = mock(Build::class.java)
+        plugin = Plugin()
+        plugin.groupId = "me.kpavlov.ksp.maven"
+        plugin.artifactId = "ksp-maven-plugin"
+
+        `when`(session.projects).thenReturn(listOf(project))
+        `when`(project.build).thenReturn(build)
+        `when`(build.pluginsAsMap).thenReturn(mapOf("me.kpavlov.ksp.maven:ksp-maven-plugin" to plugin))
+    }
+
+    @Test
+    fun `should add executions when extensions is true`() {
+        plugin.isExtensions = true
+
+        participant.afterProjectsRead(session)
+
+        val executions = plugin.executions
+        executions shouldHaveSize 2
+
+        val mainExecution = executions.find { it.id == "process-main-sources" }
+        mainExecution shouldNotBeNull {
+            assertSoftly {
+                phase shouldBe "generate-sources"
+                goals shouldBe listOf("process")
+            }
+        }
+
+        val testExecution = executions.find { it.id == "process-test-sources" }
+        testExecution shouldNotBeNull {
+            assertSoftly {
+                phase shouldBe "generate-test-sources"
+                goals shouldBe listOf("process-test")
+            }
+        }
+    }
+
+    @Test
+    fun `should not add executions when extensions is false`() {
+        plugin.isExtensions = false
+
+        participant.afterProjectsRead(session)
+
+        plugin.executions.shouldBeEmpty()
+    }
+
+    @Test
+    fun `should not overwrite existing executions`() {
+        plugin.isExtensions = true
+        val existingExecution = PluginExecution()
+        existingExecution.id = "process-main-sources"
+        plugin.addExecution(existingExecution)
+
+        participant.afterProjectsRead(session)
+
+        val executions = plugin.executions
+        executions shouldHaveSize 2
+        executions shouldContain existingExecution
+        executions.any { it.id == "process-test-sources" } shouldBe true
+    }
+}


### PR DESCRIPTION
# feat: Add `KspLifecycleParticipant` to dynamically configure plugin executions

- Introduced `KspLifecycleParticipant` to handle automatic binding of plugin executions for source and test processing phases.
- Registered the participant in `javax.inject.Named`.
- Added unit tests for execution scenarios, including extensions check and existing execution handling.
- Simplified sample project POM by removing redundant execution configurations.


## 🔄 Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## 🧪 How Has This Been Tested?

**Sample project is failing against version 0.2.0: this is expected due to pom.xml change**

**Testing checklist:**
- [x] 🧪 Unit tests added/updated
- [x] 🚀 Integration tests added/updated
- [x] 👌 Manual testing performed
- [x] ✅ All existing tests pass locally
